### PR TITLE
Fix plotly upgrade

### DIFF
--- a/Visualizations/plotly.ipynb
+++ b/Visualizations/plotly.ipynb
@@ -69,7 +69,7 @@
     "#automated plotly update\n",
     "import plotly\n",
     "if tuple(int(x) for x in plotly.__version__.split('.')) < (4,14):\n",
-    "  !pip install plotly-express --upgrade\n",
+    "  !pip install plotly --upgrade\n",
     "  exit()"
    ]
   },


### PR DESCRIPTION
Calling upgrade on plotly-express does not upgrade plotly as plotly-express only requires plotly>=4.1.0.  Call upgrade on plotly directly.  This fixes several display issues including the 'Variable=Value' format in plot legends.

```#automated plotly update
import plotly
if tuple(int(x) for x in plotly.__version__.split('.')) < (4,14):`
  !pip install plotly-express --upgrade`
  exit()
```

_Collecting plotly-express
  Downloading 
...
**Requirement already satisfied, skipping upgrade: plotly>=4.1.0 in /usr/local/lib/python3.7/dist-packages (from plotly-express) (4.4.1)**
...
Installing collected packages: plotly-express
Successfully installed plotly-express-0.4.1_
